### PR TITLE
Shrink the sprite to a minimum width/height when packing multiple bins at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,13 +74,14 @@ ShelfPack.prototype.pack = function(bins, options) {
     if (this.shelves.length > 0) {
         var w2 = 0;
         var h2 = 0;
+        
         for (var j = 0; j < this.shelves.length; j++) {
             var shelf = this.shelves[j];
             h2 += shelf.h;  
             w2 = Math.max(shelf.w - shelf.free, w2);  
         }
-        this.w = w2;
-        this.h = h2;        
+        
+        this.resize(w2, h2);       
     }
        
     return results;
@@ -176,7 +177,6 @@ ShelfPack.prototype.clear = function() {
 
 /**
  * Resize the sprite.
- * The resize will fail if the requested dimensions are smaller than the current sprite dimensions.
  *
  * @param   {number}  w  Requested new sprite width
  * @param   {number}  h  Requested new sprite height
@@ -185,10 +185,6 @@ ShelfPack.prototype.clear = function() {
  * sprite.resize(256, 256);
  */
 ShelfPack.prototype.resize = function(w, h) {
-    if (w < this.w || h < this.h) {
-        return false;
-    }
-
     this.w = w;
     this.h = h;
     for (var i = 0; i < this.shelves.length; i++) {
@@ -239,7 +235,6 @@ Shelf.prototype.alloc = function(w, h) {
 
 /**
  * Resize the shelf.
- * The resize will fail if the requested width is smaller than the current shelf width.
  *
  * @private
  * @param   {number}  w  Requested new width of the shelf
@@ -248,9 +243,6 @@ Shelf.prototype.alloc = function(w, h) {
  * shelf.resize(512);
  */
 Shelf.prototype.resize = function(w) {
-    if (w < this.w) {
-        return false;
-    }
     this.free += (w - this.w);
     this.w = w;
     return true;

--- a/index.js
+++ b/index.js
@@ -66,7 +66,23 @@ ShelfPack.prototype.pack = function(bins, options) {
             results.push(allocation);
         }
     }
-
+    
+    // Shrink the width/height of the sprite to the bare minimum. 
+    // Since shelf-pack doubles first width, then height when running out of shelf space
+    // this can result in fairly large unused space both in width and height if that happens
+    // towards the end of bin packing.
+    if (this.shelves.length > 0) {
+        var w2 = 0;
+        var h2 = 0;
+        for (var j = 0; j < this.shelves.length; j++) {
+            var shelf = this.shelves[j];
+            h2 += shelf.h;  
+            w2 = Math.max(shelf.w - shelf.free, w2);  
+        }
+        this.w = w2;
+        this.h = h2;        
+    }
+       
     return results;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -183,6 +183,25 @@ test('ShelfPack', function(t) {
         t.same([sprite.w, sprite.h], [40, 80]);
         t.end();
     });
+    
+    t.test('minimal sprite width and height', function(t) {
+        var bins = [
+            { id: 'a', width: 10, height: 10 },
+            { id: 'b', width: 5, height: 15 },
+            { id: 'c', width: 25, height: 15 },
+            { id: 'd', width: 10, height: 20 }
+        ];
+    
+        var sprite = new ShelfPack(10, 10, { autoResize: true });
+        sprite.pack(bins);
+
+        // Since shelf-pack doubles width/height when packing bins one by one
+        // (first width, then height) this would result in a 50x60 sprite here. 
+        // But this can be shrunk to a 30x45 sprite.       
+        t.same([sprite.w, sprite.h], [30, 45]);
+        
+        t.end();
+    });
 
     t.test('clear succeeds', function(t) {
         var sprite = new ShelfPack(10, 10);

--- a/test/index.js
+++ b/test/index.js
@@ -223,12 +223,5 @@ test('ShelfPack', function(t) {
         t.end();
     });
 
-    t.test('resize smaller fails', function(t) {
-        var sprite = new ShelfPack(10, 10);
-        t.notOk(sprite.resize(10, 9));
-        t.notOk(sprite.resize(9, 10));
-        t.end();
-    });
-
     t.end();
 });


### PR DESCRIPTION
Shrink the width/height of the sprite to the bare minimum. Since shelf-pack doubles first width, then height when running out of shelf space, this can result in fairly large unused space both in width and height if that happens towards the end of bin packing. In my use case with a fairly large sprite it created ~800px of unused height. 
