### PR TITLE
Refcounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ BinPack batch allocate random height and width bins x 0.51 ops/sec ±1.37% (6 ru
 
 ### Usage
 
-#### Basic
+#### Basic Usage
 
 ```js
 var ShelfPack = require('shelf-pack');
@@ -57,15 +57,22 @@ var sprite = new ShelfPack(64, 64);
 
 // Pack bins one at a time..
 for (var i = 0; i < 5; i++) {
-    var bin = sprite.packOne(32, 32);   // request width, height
-    // returns an bin object with `x`, `y`, `w`, `h`, `width`, `height` properties..
+    // packOne() accepts parameters: `width`, `height`, `id`
+    // and returns a single allocated Bin object..
+    // `id` is optional - if you skip it, shelf-pack will make up a number for you..
+    // (Protip: numeric ids are much faster than string ids)
 
-    if (bin) {
-        console.log('bin packed at ' + bin.x + ', ' + bin.y);
-    } else {
-        console.log('out of space');
-    }
+    var bin = sprite.packOne(32, 32);
+    console.log(bin || 'out of space');
 }
+
+/* output:
+Bin { id: 1, x: 0, y: 0, w: 32, h: 32, refcount: 1 }
+Bin { id: 2, x: 32, y: 0, w: 32, h: 32, refcount: 1 }
+Bin { id: 3, x: 0, y: 32, w: 32, h: 32, refcount: 1 }
+Bin { id: 4, x: 32, y: 32, w: 32, h: 32, refcount: 1 }
+out of space
+*/
 
 // Clear sprite and start over..
 sprite.clear();
@@ -86,38 +93,110 @@ var ShelfPack = require('shelf-pack');
 var sprite = new ShelfPack(10, 10, { autoResize: true });
 
 // Bins can be allocated in batches..
-// Each bin should have `width`, `height` (or `w`, `h`) properties..
-var bins = [
+// Each requested bin should have `w`, `h` (or `width`, `height`) properties..
+var requests = [
     { id: 'a', width: 10, height: 10 },
     { id: 'b', width: 10, height: 12 },
     { id: 'c', w: 10, h: 12 },
     { id: 'd', w: 10, h: 10 }
 ];
 
-var results = sprite.pack(bins);
-// returns an Array of packed bins objects with `x`, `y`, `w`, `h`, `width`, `height` properties..
+// pack() returns an Array of packed Bin objects..
+var results = sprite.pack(requests);
 
 results.forEach(function(bin) {
-    console.log('bin packed at ' + bin.x + ', ' + bin.y);
+    console.log(bin);
 });
 
+/* output:
+Bin { id: 'a', x: 0, y: 0, w: 10, h: 10, refcount: 1 }
+Bin { id: 'b', x: 0, y: 10, w: 10, h: 12, refcount: 1 }
+Bin { id: 'c', x: 10, y: 10, w: 10, h: 12, refcount: 1 }
+Bin { id: 'd', x: 10, y: 0, w: 10, h: 10, refcount: 1 }
+*/
 
 // If you don't mind letting ShelfPack modify your objects,
 // the `inPlace` option will decorate your bin objects with `x` and `y` properties.
 // Fancy!
-var moreBins = [
+var myBins = [
     { id: 'e', width: 12, height: 24 },
     { id: 'f', width: 12, height: 12 },
     { id: 'g', w: 10, h: 10 }
 ];
 
-sprite.pack(moreBins, { inPlace: true });
-moreBins.forEach(function(bin) {
-    console.log('bin packed at ' + bin.x + ', ' + bin.y);
+sprite.pack(myBins, { inPlace: true });
+myBins.forEach(function(bin) {
+    console.log(bin);
 });
 
+/* output:
+{ id: 'e', width: 12, height: 24, x: 0, y: 22 }
+{ id: 'f', width: 12, height: 12, x: 20, y: 10 }
+{ id: 'g', w: 10, h: 10, x: 20, y: 0 }
+*/
 
 ```
+
+#### Reference Counting
+
+```js
+var ShelfPack = require('shelf-pack');
+
+// Initialize the sprite with a width and height..
+var sprite = new ShelfPack(64, 64);
+
+// Allocated bins are automatically reference counted.
+// They start out having a refcount of 1.
+[100, 101, 102].forEach(function(id) {
+    var bin = sprite.packOne(16, 16, id);
+    console.log(bin);
+});
+
+/* output:
+Bin { id: 100, x: 0, y: 0, w: 16, h: 16, refcount: 1 }
+Bin { id: 101, x: 16, y: 0, w: 16, h: 16, refcount: 1 }
+Bin { id: 102, x: 32, y: 0, w: 16, h: 16, refcount: 1 }
+*/
+
+// If you try to pack the same id again, shelf-pack will not re-pack it.
+// Instead, it will increment the reference count automatically..
+var bin102 = sprite.packOne(16, 16, 102);
+console.log(bin102);
+
+/* output:
+Bin { id: 102, x: 32, y: 0, w: 16, h: 16, refcount: 2 }
+*/
+
+// You can also manually increment the reference count..
+var bin101 = sprite.getBin(101);
+sprite.ref(bin101);
+console.log(bin101);
+
+/* output:
+Bin { id: 101, x: 16, y: 0, w: 16, h: 16, refcount: 2 }
+*/
+
+// ...and decrement it!
+var bin100 = sprite.getBin(100);
+sprite.unref(bin100);
+console.log(bin100);
+
+/* output:
+Bin { id: 100, x: 0, y: 0, w: 16, h: 16, refcount: 0 }
+*/
+
+// Bins with a refcount of 0 are considered free space.
+// Next time a bin is packed, shelf-back tries to reuse free space first.
+// See how Bin 103 gets allocated at [0,0] - Bin 100's old spot!
+var bin103 = sprite.packOne(16, 16, 103);
+console.log(bin103);
+
+/* output:
+Bin { id: 103, x: 0, y: 0, w: 16, h: 16, refcount: 1 }
+*/
+
+```
+
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ Really fast!  `shelf-pack` is several orders of magnitude faster than the more g
 ```bash
 > npm run bench
 
-ShelfPack allocate fixed bins x 1,923 ops/sec ±1.44% (85 runs sampled)
-ShelfPack allocate random width bins x 1,707 ops/sec ±1.39% (84 runs sampled)
-ShelfPack allocate random height bins x 1,632 ops/sec ±2.07% (86 runs sampled)
-ShelfPack allocate random height and width bins x 1,212 ops/sec ±0.81% (89 runs sampled)
-BinPack allocate fixed bins x 2.26 ops/sec ±6.89% (10 runs sampled)
-BinPack allocate random width bins x 2.22 ops/sec ±7.21% (10 runs sampled)
-BinPack allocate random height bins x 2.21 ops/sec ±7.34% (10 runs sampled)
-BinPack allocate random height and width bins x 1.95 ops/sec ±4.81% (9 runs sampled)
+ShelfPack single allocate fixed size bins x 1,433 ops/sec ±0.85% (90 runs sampled)
+ShelfPack single allocate random width bins x 1,326 ops/sec ±1.28% (87 runs sampled)
+ShelfPack single allocate random height bins x 1,369 ops/sec ±0.93% (88 runs sampled)
+ShelfPack single allocate random height and width bins x 1,246 ops/sec ±0.86% (88 runs sampled)
+ShelfPack batch allocate fixed size bins x 1,347 ops/sec ±1.28% (87 runs sampled)
+ShelfPack batch allocate random width bins x 1,241 ops/sec ±1.00% (88 runs sampled)
+ShelfPack batch allocate random height bins x 1,250 ops/sec ±0.98% (87 runs sampled)
+ShelfPack batch allocate random height and width bins x 1,134 ops/sec ±1.20% (87 runs sampled)
+BinPack batch allocate fixed size bins x 2.21 ops/sec ±6.60% (10 runs sampled)
+BinPack batch allocate random width bins x 0.50 ops/sec ±2.25% (6 runs sampled)
+BinPack batch allocate random height bins x 0.51 ops/sec ±1.97% (6 runs sampled)
+BinPack batch allocate random height and width bins x 0.51 ops/sec ±1.37% (6 runs sampled)
 ```
 
 

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -32,18 +32,6 @@ for (var i = 0; i < N; i++) {
 var suite = new Benchmark.Suite();
 
 suite
-    .add('ShelfPack batch allocate fixed size bins', function() {
-        new ShelfPack(dim, dim).pack(fixedBoth);
-    })
-    .add('ShelfPack batch allocate random width bins', function() {
-        new ShelfPack(dim, dim).pack(randWidth);
-    })
-    .add('ShelfPack batch allocate random height bins', function() {
-        new ShelfPack(dim, dim).pack(randHeight);
-    })
-    .add('ShelfPack batch allocate random height and width bins', function() {
-        new ShelfPack(dim, dim).pack(randBoth);
-    })
     .add('ShelfPack single allocate fixed size bins', function() {
         var pack = new ShelfPack(dim, dim);
         var ok = true;
@@ -75,6 +63,18 @@ suite
             ok = pack.packOne(randBoth[j].width, randBoth[j].height);
             if (!ok) throw new Error('out of space');
         }
+    })
+    .add('ShelfPack batch allocate fixed size bins', function() {
+        new ShelfPack(dim, dim).pack(fixedBoth);
+    })
+    .add('ShelfPack batch allocate random width bins', function() {
+        new ShelfPack(dim, dim).pack(randWidth);
+    })
+    .add('ShelfPack batch allocate random height bins', function() {
+        new ShelfPack(dim, dim).pack(randHeight);
+    })
+    .add('ShelfPack batch allocate random height and width bins', function() {
+        new ShelfPack(dim, dim).pack(randBoth);
     })
     .add('BinPack batch allocate fixed size bins', function() {
         BinPack(fixedBoth);

--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ ShelfPack.prototype.packOne = function(w, h, id) {
         bin.id = id;
         bin.w = w;
         bin.h = h;
+        bin.refcount = 0;
         this.bins[id] = bin;
         this.ref(bin);
         return bin;

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "node": ">=4.0.0"
   },
   "scripts": {
-    "pretest": "rollup -f umd -n ShelfPack index.js --no-indent --no-strict -o index.umd.js",
-    "lint": "eslint index.js test/ bench/",
+    "bench": "npm run build && node bench/bench.js",
+    "build": "rollup -f umd -n ShelfPack index.js --no-indent --no-strict -o index.umd.js",
     "docs": "documentation build index.js --lint --github --format html --output docs/",
-    "test": "npm run lint && tap --cov test/*.js",
-    "bench": "node bench/bench.js"
+    "lint": "eslint index.js test/ bench/",
+    "test": "npm run build && npm run lint && tap --cov test/*.js"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -130,56 +130,56 @@ test('ShelfPack', function(t) {
 
     t.test('single allocates same height bins on existing shelf', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 20, y: 0, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 20, y: 0, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.end();
     });
 
     t.test('single allocates larger bins on new shelf', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { id: '__2', x: 0, y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { id: '__3', x: 0, y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0, y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0, y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
         t.end();
     });
 
     t.test('single allocates shorter bins on existing shelf, minimizing waste', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { id: '__2', x: 0,  y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { id: '__3', x: 0,  y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
-        t.deepEqual(sprite.packOne(10, 9),  { id: '__4', x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }, 'shelf 1, 10x9 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0,  y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0,  y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
+        t.deepEqual(sprite.packOne(10, 9),  { id: 4, x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }, 'shelf 1, 10x9 bin');
         t.end();
     });
 
     t.test('not enough room', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.notOk(sprite.packOne(10, 10), 'not enough room');
         t.end();
     });
 
     t.test('autoResize grows sprite dimensions by width then height', function(t) {
         var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.same([sprite.w, sprite.h], [10, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0,  w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0,  w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 0,  y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0,  y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__4', x: 10, y: 10, w: 10, h: 10, refcount: 1 }, 'fourth 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 4, x: 10, y: 10, w: 10, h: 10, refcount: 1 }, 'fourth 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__5', x: 20, y: 0,  w: 10, h: 10, refcount: 1 }, 'fifth 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 5, x: 20, y: 0,  w: 10, h: 10, refcount: 1 }, 'fifth 10x10 bin');
         t.same([sprite.w, sprite.h], [40, 20]);
         t.end();
     });
 
     t.test('autoResize accomodates big bin requests', function(t) {
         var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(20, 10), { id: '__1', x: 0,  y: 0,  w: 20, h: 10, refcount: 1 }, '20x10 bin');
+        t.deepEqual(sprite.packOne(20, 10), { id: 1, x: 0,  y: 0,  w: 20, h: 10, refcount: 1 }, '20x10 bin');
         t.same([sprite.w, sprite.h], [40, 10]);
-        t.deepEqual(sprite.packOne(10, 40), { id: '__2', x: 0,  y: 10, w: 10, h: 40, refcount: 1 }, '40x10 bin');
+        t.deepEqual(sprite.packOne(10, 40), { id: 2, x: 0,  y: 10, w: 10, h: 40, refcount: 1 }, '40x10 bin');
         t.same([sprite.w, sprite.h], [40, 80]);
         t.end();
     });
@@ -205,21 +205,21 @@ test('ShelfPack', function(t) {
 
     t.test('clear succeeds', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.notOk(sprite.packOne(10, 10), 'not enough room');
 
         sprite.clear();
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.end();
     });
 
     t.test('resize larger succeeds', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.ok(sprite.resize(20, 10));
-        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
         t.ok(sprite.resize(20, 20));
-        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 0, y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0, y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.end();
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,222 +4,417 @@ var test = require('tap').test;
 var ShelfPack = require('../.');
 
 test('ShelfPack', function(t) {
-    t.test('batch pack allocates same height bins on existing shelf', function(t) {
-        var sprite = new ShelfPack(64, 64),
-            bins = [
+
+    t.test('batch pack()', function(t) {
+        t.test('batch pack() allocates same height bins on existing shelf', function(t) {
+            var sprite = new ShelfPack(64, 64),
+                bins = [
+                    { id: 'a', width: 10, height: 10 },
+                    { id: 'b', width: 10, height: 10 },
+                    { id: 'c', width: 10, height: 10 }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
+                ];
+
+            var results = sprite.pack(bins);
+            t.deepEqual(results, expectedResults);
+            t.end();
+        });
+
+        t.test('batch pack() allocates larger bins on new shelf', function(t) {
+            var sprite = new ShelfPack(64, 64),
+                bins = [
+                    { id: 'a', width: 10, height: 10 },
+                    { id: 'b', width: 10, height: 15 },
+                    { id: 'c', width: 10, height: 20 }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0, y: 0,  w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 0, y: 10, w: 10, h: 15, refcount: 1 },
+                    { id: 'c', x: 0, y: 25, w: 10, h: 20, refcount: 1 }
+                ];
+
+            var results = sprite.pack(bins);
+            t.deepEqual(results, expectedResults);
+            t.end();
+        });
+
+        t.test('batch pack() allocates shorter bins on existing shelf, minimizing waste', function(t) {
+            var sprite = new ShelfPack(64, 64),
+                bins = [
+                    { id: 'a', width: 10, height: 10 },
+                    { id: 'b', width: 10, height: 15 },
+                    { id: 'c', width: 10, height: 20 },
+                    { id: 'd', width: 10, height: 9  }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 0,  y: 10, w: 10, h: 15, refcount: 1 },
+                    { id: 'c', x: 0,  y: 25, w: 10, h: 20, refcount: 1 },
+                    { id: 'd', x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }
+                ];
+
+            var results = sprite.pack(bins);
+            t.deepEqual(results, expectedResults);
+            t.end();
+        });
+
+        t.test('batch pack() accepts `w`, `h` for `width`, `height`', function(t) {
+            var sprite = new ShelfPack(64, 64),
+                bins = [
+                    { id: 'a', w: 10, h: 10 },
+                    { id: 'b', w: 10, h: 10 },
+                    { id: 'c', w: 10, h: 10 }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
+                ];
+
+            var results = sprite.pack(bins);
+            t.deepEqual(results, expectedResults);
+            t.end();
+        });
+
+        t.test('batch pack() adds `x`, `y` properties to bins with `inPlace` option', function(t) {
+            var sprite = new ShelfPack(64, 64),
+                bins = [
+                    { id: 'a', w: 10, h: 10 },
+                    { id: 'b', w: 10, h: 10 },
+                    { id: 'c', w: 10, h: 10 }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                    { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
+                ],
+                expectedBins = [
+                    { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
+                    { id: 'b', w: 10, h: 10, x: 10, y: 0 },
+                    { id: 'c', w: 10, h: 10, x: 20, y: 0 }
+                ];
+
+            var results = sprite.pack(bins, { inPlace: true });
+            t.deepEqual(results, expectedResults);
+            t.deepEqual(bins, expectedBins);
+            t.end();
+        });
+
+        t.test('batch pack() skips bins if not enough room', function(t) {
+            var sprite = new ShelfPack(20, 20),
+                bins = [
+                    { id: 'a', w: 10, h: 10 },
+                    { id: 'b', w: 10, h: 10 },
+                    { id: 'c', w: 10, h: 30 },  // should skip
+                    { id: 'd', w: 10, h: 10 }
+                ],
+                expectedResults = [
+                    { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
+                    { id: 'b', x: 10, y: 0,  w: 10, h: 10, refcount: 1 },
+                    { id: 'd', x: 0,  y: 10, w: 10, h: 10, refcount: 1 }
+                ],
+                expectedBins = [
+                    { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
+                    { id: 'b', w: 10, h: 10, x: 10, y: 0 },
+                    { id: 'c', w: 10, h: 30 },
+                    { id: 'd', w: 10, h: 10, x: 0, y: 10 }
+                ];
+
+            var results = sprite.pack(bins, { inPlace: true });
+            t.deepEqual(results, expectedResults);
+            t.deepEqual(bins, expectedBins);
+            t.end();
+        });
+
+        t.test('batch pack() results in minimal sprite width and height', function(t) {
+            var bins = [
                 { id: 'a', width: 10, height: 10 },
-                { id: 'b', width: 10, height: 10 },
-                { id: 'c', width: 10, height: 10 }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
+                { id: 'b', width: 5,  height: 15 },
+                { id: 'c', width: 25, height: 15 },
+                { id: 'd', width: 10, height: 20 }
             ];
 
-        var results = sprite.pack(bins);
-        t.deepEqual(results, expectedResults);
-        t.end();
-    });
+            var sprite = new ShelfPack(10, 10, { autoResize: true });
+            sprite.pack(bins);
 
-    t.test('batch pack allocates larger bins on new shelf', function(t) {
-        var sprite = new ShelfPack(64, 64),
-            bins = [
-                { id: 'a', width: 10, height: 10 },
-                { id: 'b', width: 10, height: 15 },
-                { id: 'c', width: 10, height: 20 }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0, y: 0,  w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 0, y: 10, w: 10, h: 15, refcount: 1 },
-                { id: 'c', x: 0, y: 25, w: 10, h: 20, refcount: 1 }
-            ];
+            // Since shelf-pack doubles width/height when packing bins one by one
+            // (first width, then height) this would result in a 50x60 sprite here.
+            // But this can be shrunk to a 30x45 sprite.
+            t.same([sprite.w, sprite.h], [30, 45]);
 
-        var results = sprite.pack(bins);
-        t.deepEqual(results, expectedResults);
-        t.end();
-    });
-
-    t.test('batch pack allocates shorter bins on existing shelf, minimizing waste', function(t) {
-        var sprite = new ShelfPack(64, 64),
-            bins = [
-                { id: 'a', width: 10, height: 10 },
-                { id: 'b', width: 10, height: 15 },
-                { id: 'c', width: 10, height: 20 },
-                { id: 'd', width: 10, height: 9  }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 0,  y: 10, w: 10, h: 15, refcount: 1 },
-                { id: 'c', x: 0,  y: 25, w: 10, h: 20, refcount: 1 },
-                { id: 'd', x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }
-            ];
-
-        var results = sprite.pack(bins);
-        t.deepEqual(results, expectedResults);
-        t.end();
-    });
-
-    t.test('batch pack accepts `w`, `h` for `width`, `height`', function(t) {
-        var sprite = new ShelfPack(64, 64),
-            bins = [
-                { id: 'a', w: 10, h: 10 },
-                { id: 'b', w: 10, h: 10 },
-                { id: 'c', w: 10, h: 10 }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
-            ];
-
-        var results = sprite.pack(bins);
-        t.deepEqual(results, expectedResults);
-        t.end();
-    });
-
-    t.test('batch pack adds `x`, `y` properties to bins with `inPlace` option', function(t) {
-        var sprite = new ShelfPack(64, 64),
-            bins = [
-                { id: 'a', w: 10, h: 10 },
-                { id: 'b', w: 10, h: 10 },
-                { id: 'c', w: 10, h: 10 }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
-                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
-            ],
-            expectedBins = [
-                { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
-                { id: 'b', w: 10, h: 10, x: 10, y: 0 },
-                { id: 'c', w: 10, h: 10, x: 20, y: 0 }
-            ];
-
-        var results = sprite.pack(bins, { inPlace: true });
-        t.deepEqual(results, expectedResults);
-        t.deepEqual(bins, expectedBins);
-        t.end();
-    });
-
-    t.test('batch pack skips bins if not enough room', function(t) {
-        var sprite = new ShelfPack(20, 20),
-            bins = [
-                { id: 'a', w: 10, h: 10 },
-                { id: 'b', w: 10, h: 10 },
-                { id: 'c', w: 10, h: 30 },  // should skip
-                { id: 'd', w: 10, h: 10 }
-            ],
-            expectedResults = [
-                { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
-                { id: 'b', x: 10, y: 0,  w: 10, h: 10, refcount: 1 },
-                { id: 'd', x: 0,  y: 10, w: 10, h: 10, refcount: 1 }
-            ],
-            expectedBins = [
-                { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
-                { id: 'b', w: 10, h: 10, x: 10, y: 0 },
-                { id: 'c', w: 10, h: 30 },
-                { id: 'd', w: 10, h: 10, x: 0, y: 10 }
-            ];
-
-        var results = sprite.pack(bins, { inPlace: true });
-        t.deepEqual(results, expectedResults);
-        t.deepEqual(bins, expectedBins);
-        t.end();
-    });
-
-    t.test('single allocates same height bins on existing shelf', function(t) {
-        var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 20, y: 0, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
-        t.end();
-    });
-
-    t.test('single allocates larger bins on new shelf', function(t) {
-        var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0, y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0, y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
-        t.end();
-    });
-
-    t.test('single allocates shorter bins on existing shelf, minimizing waste', function(t) {
-        var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0,  y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0,  y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
-        t.deepEqual(sprite.packOne(10, 9),  { id: 4, x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }, 'shelf 1, 10x9 bin');
-        t.end();
-    });
-
-    t.test('not enough room', function(t) {
-        var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.notOk(sprite.packOne(10, 10), 'not enough room');
-        t.end();
-    });
-
-    t.test('autoResize grows sprite dimensions by width then height', function(t) {
-        var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.same([sprite.w, sprite.h], [10, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0,  w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
-        t.same([sprite.w, sprite.h], [20, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0,  y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
-        t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { id: 4, x: 10, y: 10, w: 10, h: 10, refcount: 1 }, 'fourth 10x10 bin');
-        t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { id: 5, x: 20, y: 0,  w: 10, h: 10, refcount: 1 }, 'fifth 10x10 bin');
-        t.same([sprite.w, sprite.h], [40, 20]);
-        t.end();
-    });
-
-    t.test('autoResize accomodates big bin requests', function(t) {
-        var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(20, 10), { id: 1, x: 0,  y: 0,  w: 20, h: 10, refcount: 1 }, '20x10 bin');
-        t.same([sprite.w, sprite.h], [40, 10]);
-        t.deepEqual(sprite.packOne(10, 40), { id: 2, x: 0,  y: 10, w: 10, h: 40, refcount: 1 }, '40x10 bin');
-        t.same([sprite.w, sprite.h], [40, 80]);
-        t.end();
-    });
-
-    t.test('minimal sprite width and height', function(t) {
-        var bins = [
-            { id: 'a', width: 10, height: 10 },
-            { id: 'b', width: 5,  height: 15 },
-            { id: 'c', width: 25, height: 15 },
-            { id: 'd', width: 10, height: 20 }
-        ];
-
-        var sprite = new ShelfPack(10, 10, { autoResize: true });
-        sprite.pack(bins);
-
-        // Since shelf-pack doubles width/height when packing bins one by one
-        // (first width, then height) this would result in a 50x60 sprite here.
-        // But this can be shrunk to a 30x45 sprite.
-        t.same([sprite.w, sprite.h], [30, 45]);
+            t.end();
+        });
 
         t.end();
     });
 
-    t.test('clear succeeds', function(t) {
-        var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.notOk(sprite.packOne(10, 10), 'not enough room');
 
-        sprite.clear();
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+    t.test('packOne()', function(t) {
+        t.test('packOne() allocates bins with numeric id', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin = sprite.packOne(10, 10, 1000);
+            t.deepEqual(bin, { id: 1000, x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'packed bin 1000');
+            t.deepEqual(bin, sprite.getBin(1000), 'got bin 1000');
+            t.end();
+        });
+
+        t.test('packOne() allocates bins with string id', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin = sprite.packOne(10, 10, 'foo');
+            t.deepEqual(bin, { id: 'foo', x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'packed bin "foo"');
+            t.deepEqual(bin, sprite.getBin('foo'), 'got bin "foo"');
+            t.end();
+        });
+
+        t.test('packOne() generates incremental numeric ids, if id not provided', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin1 = sprite.packOne(10, 10);
+            var bin2 = sprite.packOne(10, 10);
+            t.deepEqual(bin1.id, 1, 'packed bin 1');
+            t.deepEqual(bin2.id, 2, 'packed bin 2');
+            t.end();
+        });
+
+        t.test('packOne() does not reallocate a bin with existing id', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin1 = sprite.packOne(10, 10, 1000);
+            t.deepEqual(bin1, { id: 1000, x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'bin 1000 refcount 1');
+            t.deepEqual(bin1, sprite.getBin(1000), 'got bin 1000');
+
+            var bin2 = sprite.packOne(10, 10, 1000);
+            t.deepEqual(bin2, { id: 1000, x: 0,  y: 0, w: 10, h: 10, refcount: 2 }, 'bin 1000 refcount 2');
+            t.deepEqual(bin1, bin2, 'bin1 and bin2 are the same bin');
+            t.end();
+        });
+
+        t.test('packOne() allocates same height bins on existing shelf', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+            t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 20, y: 0, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+            t.end();
+        });
+
+        t.test('packOne() allocates larger bins on new shelf', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+            t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0, y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+            t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0, y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
+            t.end();
+        });
+
+        t.test('packOne() allocates shorter bins on existing shelf, minimizing waste', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+            t.deepEqual(sprite.packOne(10, 15), { id: 2, x: 0,  y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+            t.deepEqual(sprite.packOne(10, 20), { id: 3, x: 0,  y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
+            t.deepEqual(sprite.packOne(10, 9),  { id: 4, x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }, 'shelf 1, 10x9 bin');
+            t.end();
+        });
+
+        t.test('packOne() returns nothing if not enough room', function(t) {
+            var sprite = new ShelfPack(10, 10);
+            t.deepEqual(sprite.packOne(10, 10, 1), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.notOk(sprite.packOne(10, 10, 2), 'not enough room');
+            t.notOk(sprite.shelves[0].alloc(10, 10, 2), 'not enough room on shelf');
+            t.end();
+        });
+
+        t.test('packOne() allocates in free bin if possible', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            sprite.packOne(10, 10);
+            sprite.packOne(10, 10);
+            sprite.packOne(10, 10);
+
+            var bin2 = sprite.getBin(2);
+            sprite.unref(bin2);
+            t.deepEqual(sprite.freebins.length, 1, 'freebins length 1');
+            t.deepEqual(sprite.freebins[0], bin2, 'bin2 moved to freebins');
+
+            t.deepEqual(sprite.packOne(10, 10), { id: 4, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'reused bin2 10x10 bin');
+            t.deepEqual(sprite.freebins.length, 0, 'freebins length 0');
+
+            t.end();
+        });
+
+        t.test('packOne() allocates in free bin, minimizing waste', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            sprite.packOne(10, 10);
+            sprite.packOne(10, 15);
+            sprite.packOne(10, 20);
+
+            sprite.unref(sprite.getBin(1));
+            sprite.unref(sprite.getBin(2));
+            sprite.unref(sprite.getBin(3));
+
+            t.deepEqual(sprite.freebins.length, 3, 'freebins length 3');
+            t.deepEqual(sprite.packOne(10, 13), { id: 4, x: 0,  y: 10, w: 10, h: 13, refcount: 1 }, 'reused bin2 10x15 bin');
+            t.deepEqual(sprite.freebins.length, 2, 'freebins length 2');
+
+            t.end();
+        });
+
         t.end();
     });
 
-    t.test('resize larger succeeds', function(t) {
-        var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
-        t.ok(sprite.resize(20, 10));
-        t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
-        t.ok(sprite.resize(20, 20));
-        t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0, y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+
+    t.test('getBin()', function(t) {
+        t.test('getBin() returns undefined if Bin not found', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            t.deepEqual(sprite.getBin(1), undefined, 'undefined bin');
+            t.end();
+        });
+
+        t.test('getBin() gets a Bin by numeric id', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin = sprite.packOne(10, 10, 1);
+            t.deepEqual(sprite.getBin(1), bin, 'Bin 1');
+            t.end();
+        });
+
+        t.test('getBin() gets a Bin by string id', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin = sprite.packOne(10, 10, 'foo');
+            t.deepEqual(sprite.getBin('foo'), bin, 'Bin "foo"');
+            t.end();
+        });
+
+        t.end();
+    });
+
+
+    t.test('ref()', function(t) {
+        t.test('ref() increments the Bin refcount and updates stats', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin1 = sprite.packOne(10, 10, 1);
+            t.deepEqual(bin1.refcount, 1, 'Bin1 refcount is 1');
+            t.deepEqual(sprite.stats, { 10: 1 }, 'one bin of height 10');
+            t.deepEqual(sprite.ref(bin1), 2, 'Bin1 refcount is 2');
+            t.deepEqual(sprite.stats, { 10: 1 }, 'still one bin of height 10');
+
+            var bin2 = sprite.packOne(10, 10, 2);
+            t.deepEqual(bin2.refcount, 1, 'Bin2 refcount is 1');
+            t.deepEqual(sprite.stats, { 10: 2 }, 'two bins of height 10');
+            t.deepEqual(sprite.ref(bin2), 2, 'Bin2 refcount is 2');
+            t.deepEqual(sprite.stats, { 10: 2 }, 'still two bins of height 10');
+
+            var bin3 = sprite.packOne(10, 15, 3);
+            t.deepEqual(bin3.refcount, 1, 'Bin3 refcount is 1');
+            t.deepEqual(sprite.stats, { 10: 2, 15: 1}, 'two bins of height 10, one bin of height 15');
+            t.deepEqual(sprite.ref(bin3), 2, 'Bin3 refcount is 2');
+            t.deepEqual(sprite.stats, { 10: 2, 15: 1}, 'still two bins of height 10, one bin of height 15');
+
+            t.end();
+        });
+
+        t.end();
+    });
+
+
+    t.test('unref()', function(t) {
+        t.test('unref() decrements the Bin refcount and updates stats', function(t) {
+            var sprite = new ShelfPack(64, 64);
+
+            // setup..
+            var bin1 = sprite.packOne(10, 10, 1);
+            sprite.ref(bin1);
+            var bin2 = sprite.packOne(10, 10, 2);
+            sprite.ref(bin2);
+            var bin3 = sprite.packOne(10, 15, 3);
+            sprite.ref(bin3);
+
+            t.deepEqual(sprite.unref(bin3), 1, 'Bin3 refcount is 1');
+            t.deepEqual(sprite.stats, { 10: 2, 15: 1}, 'two bins of height 10, one bin of height 15');
+            t.deepEqual(sprite.freebins.length, 0, 'freebins empty');
+
+            t.deepEqual(sprite.unref(bin3), 0, 'Bin3 refcount is 0');
+            t.deepEqual(sprite.stats, { 10: 2, 15: 0}, 'two bins of height 10, no bins of height 15');
+            t.deepEqual(sprite.freebins.length, 1, 'freebins length 1');
+            t.deepEqual(sprite.freebins[0], bin3, 'bin3 moved to freebins');
+            t.deepEqual(sprite.getBin(3), undefined, 'getBin for Bin3 returns undefined');
+
+            t.deepEqual(sprite.unref(bin2), 1, 'Bin2 refcount is 1');
+            t.deepEqual(sprite.stats, { 10: 2, 15: 0}, 'still two bins of height 10, no bins of height 15');
+
+            t.deepEqual(sprite.unref(bin2), 0, 'Bin2 refcount is 0');
+            t.deepEqual(sprite.stats, { 10: 1, 15: 0}, 'one bin of height 10, no bins of height 15');
+            t.deepEqual(sprite.freebins.length, 2, 'freebins length 2');
+            t.deepEqual(sprite.freebins[1], bin2, 'bin2 moved to freebins');
+            t.deepEqual(sprite.getBin(2), undefined, 'getBin for Bin2 returns undefined');
+
+            t.end();
+        });
+
+        t.test('unref() does nothing if refcount is already 0', function(t) {
+            var sprite = new ShelfPack(64, 64);
+            var bin = sprite.packOne(10, 10, 1);
+            t.deepEqual(sprite.unref(bin), 0, 'Bin3 refcount is 0');
+            t.deepEqual(sprite.stats, { 10: 0}, 'no bins of height 10');
+
+            t.deepEqual(sprite.unref(bin), 0, 'Bin3 refcount is still 0');
+            t.deepEqual(sprite.stats, { 10: 0}, 'still no bins of height 10');
+
+            t.end();
+        });
+
+        t.end();
+    });
+
+
+    t.test('clear()', function(t) {
+        t.test('clear() succeeds', function(t) {
+            var sprite = new ShelfPack(10, 10);
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.notOk(sprite.packOne(10, 10), 'not enough room');
+
+            sprite.clear();
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.end();
+        });
+
+        t.end();
+    });
+
+
+    t.test('resize()', function(t) {
+        t.test('resize larger succeeds', function(t) {
+            var sprite = new ShelfPack(10, 10);
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.ok(sprite.resize(20, 10));
+            t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+            t.ok(sprite.resize(20, 20));
+            t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0, y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+            t.end();
+        });
+
+        t.test('autoResize grows sprite dimensions by width then height', function(t) {
+            var sprite = new ShelfPack(10, 10, { autoResize: true });
+            t.deepEqual(sprite.packOne(10, 10), { id: 1, x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+            t.same([sprite.w, sprite.h], [10, 10]);
+            t.deepEqual(sprite.packOne(10, 10), { id: 2, x: 10, y: 0,  w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+            t.same([sprite.w, sprite.h], [20, 10]);
+            t.deepEqual(sprite.packOne(10, 10), { id: 3, x: 0,  y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
+            t.same([sprite.w, sprite.h], [20, 20]);
+            t.deepEqual(sprite.packOne(10, 10), { id: 4, x: 10, y: 10, w: 10, h: 10, refcount: 1 }, 'fourth 10x10 bin');
+            t.same([sprite.w, sprite.h], [20, 20]);
+            t.deepEqual(sprite.packOne(10, 10), { id: 5, x: 20, y: 0,  w: 10, h: 10, refcount: 1 }, 'fifth 10x10 bin');
+            t.same([sprite.w, sprite.h], [40, 20]);
+            t.end();
+        });
+
+        t.test('autoResize accomodates big bin requests', function(t) {
+            var sprite = new ShelfPack(10, 10, { autoResize: true });
+            t.deepEqual(sprite.packOne(20, 10), { id: 1, x: 0,  y: 0,  w: 20, h: 10, refcount: 1 }, '20x10 bin');
+            t.same([sprite.w, sprite.h], [40, 10]);
+            t.deepEqual(sprite.packOne(10, 40), { id: 2, x: 0,  y: 10, w: 10, h: 40, refcount: 1 }, '40x10 bin');
+            t.same([sprite.w, sprite.h], [40, 80]);
+            t.end();
+        });
+
         t.end();
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -12,9 +12,9 @@ test('ShelfPack', function(t) {
                 { id: 'c', width: 10, height: 10 }
             ],
             expectedResults = [
-                { x: 0,  y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 10, y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 20, y: 0, w: 10, h: 10, width: 10, height: 10 }
+                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
             ];
 
         var results = sprite.pack(bins);
@@ -30,9 +30,9 @@ test('ShelfPack', function(t) {
                 { id: 'c', width: 10, height: 20 }
             ],
             expectedResults = [
-                { x: 0, y: 0,  w: 10, h: 10, width: 10, height: 10 },
-                { x: 0, y: 10, w: 10, h: 15, width: 10, height: 15 },
-                { x: 0, y: 25, w: 10, h: 20, width: 10, height: 20 }
+                { id: 'a', x: 0, y: 0,  w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 0, y: 10, w: 10, h: 15, refcount: 1 },
+                { id: 'c', x: 0, y: 25, w: 10, h: 20, refcount: 1 }
             ];
 
         var results = sprite.pack(bins);
@@ -49,10 +49,10 @@ test('ShelfPack', function(t) {
                 { id: 'd', width: 10, height: 9  }
             ],
             expectedResults = [
-                { x: 0,  y: 0,  w: 10, h: 10, width: 10, height: 10 },
-                { x: 0,  y: 10, w: 10, h: 15, width: 10, height: 15 },
-                { x: 0,  y: 25, w: 10, h: 20, width: 10, height: 20 },
-                { x: 10, y: 0,  w: 10, h: 9,  width: 10, height: 9  }
+                { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 0,  y: 10, w: 10, h: 15, refcount: 1 },
+                { id: 'c', x: 0,  y: 25, w: 10, h: 20, refcount: 1 },
+                { id: 'd', x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }
             ];
 
         var results = sprite.pack(bins);
@@ -68,9 +68,9 @@ test('ShelfPack', function(t) {
                 { id: 'c', w: 10, h: 10 }
             ],
             expectedResults = [
-                { x: 0,  y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 10, y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 20, y: 0, w: 10, h: 10, width: 10, height: 10 }
+                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
             ];
 
         var results = sprite.pack(bins);
@@ -86,9 +86,9 @@ test('ShelfPack', function(t) {
                 { id: 'c', w: 10, h: 10 }
             ],
             expectedResults = [
-                { x: 0,  y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 10, y: 0, w: 10, h: 10, width: 10, height: 10 },
-                { x: 20, y: 0, w: 10, h: 10, width: 10, height: 10 }
+                { id: 'a', x: 0,  y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 10, y: 0, w: 10, h: 10, refcount: 1 },
+                { id: 'c', x: 20, y: 0, w: 10, h: 10, refcount: 1 }
             ],
             expectedBins = [
                 { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
@@ -111,9 +111,9 @@ test('ShelfPack', function(t) {
                 { id: 'd', w: 10, h: 10 }
             ],
             expectedResults = [
-                { x: 0,  y: 0,  w: 10, h: 10, width: 10, height: 10 },
-                { x: 10, y: 0,  w: 10, h: 10, width: 10, height: 10 },
-                { x: 0,  y: 10, w: 10, h: 10, width: 10, height: 10 }
+                { id: 'a', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 },
+                { id: 'b', x: 10, y: 0,  w: 10, h: 10, refcount: 1 },
+                { id: 'd', x: 0,  y: 10, w: 10, h: 10, refcount: 1 }
             ],
             expectedBins = [
                 { id: 'a', w: 10, h: 10, x: 0,  y: 0 },
@@ -130,56 +130,56 @@ test('ShelfPack', function(t) {
 
     t.test('single allocates same height bins on existing shelf', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0,  y: 0, w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { x: 10, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'second 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 10), { x: 20, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 20, y: 0, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.end();
     });
 
     t.test('single allocates larger bins on new shelf', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 0,  w: 10, h: 10, width: 10, height: 10 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { x: 0, y: 10, w: 10, h: 15, width: 10, height: 15 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { x: 0, y: 25, w: 10, h: 20, width: 10, height: 20 }, 'shelf 3, 10x20 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 15), { id: '__2', x: 0, y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(sprite.packOne(10, 20), { id: '__3', x: 0, y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
         t.end();
     });
 
     t.test('single allocates shorter bins on existing shelf, minimizing waste', function(t) {
         var sprite = new ShelfPack(64, 64);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0,  y: 0,  w: 10, h: 10, width: 10, height: 10 }, 'shelf 1, 10x10 bin');
-        t.deepEqual(sprite.packOne(10, 15), { x: 0,  y: 10, w: 10, h: 15, width: 10, height: 15 }, 'shelf 2, 10x15 bin');
-        t.deepEqual(sprite.packOne(10, 20), { x: 0,  y: 25, w: 10, h: 20, width: 10, height: 20 }, 'shelf 3, 10x20 bin');
-        t.deepEqual(sprite.packOne(10, 9),  { x: 10, y: 0,  w: 10, h: 9,  width: 10, height: 9  }, 'shelf 1, 10x9 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'shelf 1, 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 15), { id: '__2', x: 0,  y: 10, w: 10, h: 15, refcount: 1 }, 'shelf 2, 10x15 bin');
+        t.deepEqual(sprite.packOne(10, 20), { id: '__3', x: 0,  y: 25, w: 10, h: 20, refcount: 1 }, 'shelf 3, 10x20 bin');
+        t.deepEqual(sprite.packOne(10, 9),  { id: '__4', x: 10, y: 0,  w: 10, h: 9,  refcount: 1 }, 'shelf 1, 10x9 bin');
         t.end();
     });
 
     t.test('not enough room', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.notOk(sprite.packOne(10, 10), 'not enough room');
         t.end();
     });
 
     t.test('autoResize grows sprite dimensions by width then height', function(t) {
         var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(10, 10), { x: 0,  y: 0,  w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0,  y: 0,  w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.same([sprite.w, sprite.h], [10, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { x: 10, y: 0,  w: 10, h: 10, width: 10, height: 10 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0,  w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 10]);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0,  y: 10, w: 10, h: 10, width: 10, height: 10 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 0,  y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { x: 10, y: 10, w: 10, h: 10, width: 10, height: 10 }, 'fourth 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__4', x: 10, y: 10, w: 10, h: 10, refcount: 1 }, 'fourth 10x10 bin');
         t.same([sprite.w, sprite.h], [20, 20]);
-        t.deepEqual(sprite.packOne(10, 10), { x: 20, y: 0,  w: 10, h: 10, width: 10, height: 10 }, 'fifth 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__5', x: 20, y: 0,  w: 10, h: 10, refcount: 1 }, 'fifth 10x10 bin');
         t.same([sprite.w, sprite.h], [40, 20]);
         t.end();
     });
 
     t.test('autoResize accomodates big bin requests', function(t) {
         var sprite = new ShelfPack(10, 10, { autoResize: true });
-        t.deepEqual(sprite.packOne(20, 10), { x: 0,  y: 0,  w: 20, h: 10, width: 20, height: 10 }, '20x10 bin');
+        t.deepEqual(sprite.packOne(20, 10), { id: '__1', x: 0,  y: 0,  w: 20, h: 10, refcount: 1 }, '20x10 bin');
         t.same([sprite.w, sprite.h], [40, 10]);
-        t.deepEqual(sprite.packOne(10, 40), { x: 0,  y: 10, w: 10, h: 40, width: 10, height: 40 }, '40x10 bin');
+        t.deepEqual(sprite.packOne(10, 40), { id: '__2', x: 0,  y: 10, w: 10, h: 40, refcount: 1 }, '40x10 bin');
         t.same([sprite.w, sprite.h], [40, 80]);
         t.end();
     });
@@ -187,7 +187,7 @@ test('ShelfPack', function(t) {
     t.test('minimal sprite width and height', function(t) {
         var bins = [
             { id: 'a', width: 10, height: 10 },
-            { id: 'b', width: 5, height: 15 },
+            { id: 'b', width: 5,  height: 15 },
             { id: 'c', width: 25, height: 15 },
             { id: 'd', width: 10, height: 20 }
         ];
@@ -205,21 +205,21 @@ test('ShelfPack', function(t) {
 
     t.test('clear succeeds', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.notOk(sprite.packOne(10, 10), 'not enough room');
 
         sprite.clear();
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.end();
     });
 
     t.test('resize larger succeeds', function(t) {
         var sprite = new ShelfPack(10, 10);
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'first 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__1', x: 0, y: 0, w: 10, h: 10, refcount: 1 }, 'first 10x10 bin');
         t.ok(sprite.resize(20, 10));
-        t.deepEqual(sprite.packOne(10, 10), { x: 10, y: 0, w: 10, h: 10, width: 10, height: 10 }, 'second 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__2', x: 10, y: 0, w: 10, h: 10, refcount: 1 }, 'second 10x10 bin');
         t.ok(sprite.resize(20, 20));
-        t.deepEqual(sprite.packOne(10, 10), { x: 0, y: 10, w: 10, h: 10, width: 10, height: 10 }, 'third 10x10 bin');
+        t.deepEqual(sprite.packOne(10, 10), { id: '__3', x: 0, y: 10, w: 10, h: 10, refcount: 1 }, 'third 10x10 bin');
         t.end();
     });
 


### PR DESCRIPTION
This closes #3 
1. Each bin now has a unique identifier.
   If no identifier is supplied to the `packOne` function, a numeric `id` will be generated.
   Note: The `id` is used as an object index, so numeric ids are 3x faster than string ids!
2. Bins are automatically refcounted (i.e. a newly packed Bin will have a refcount of 1).  
3. ShelfPack now supports `ref(bin)` and `unref(bin)` functions to track of which bins are being used by calling code.
4. When a Bin's refcount decrements to 0, the Bin will be marked as free and its space may be reused by the packing code.
